### PR TITLE
passes original event into change handlers

### DIFF
--- a/src/megalist.js
+++ b/src/megalist.js
@@ -269,14 +269,21 @@
                 }
                 
                 if ( triggerEvent ) {
-                    var index = $(target).attr( "list-index" );
-                    if (index === this.selectedIndex) { return false; }
+                    var self = this,
+                        index = $(target).attr( "list-index" );
+                    if (index === this.selectedIndex) {
+                      var data = { selectedIndex: index, 
+                                   srcElement: $(target), 
+                                   originalEvent: event,
+                                   item: self.dataProvider[index]  };
+                      var e = jQuery.Event("nochange", data);
+                      self.$el.trigger( e );
+                      return false; 
+                    }
                     this.setSelectedIndex( index );
-                
                     //make this asynch so that any "alert()" on a change event
                     //does not block the UI from updating the selected row
                     //this is particularly an issue on mobile devices
-                    var self = this;
                     setTimeout( function() {
                             var data = { selectedIndex: index, 
                                          srcElement: $(target), 

--- a/src/megalist.js
+++ b/src/megalist.js
@@ -280,6 +280,7 @@
                     setTimeout( function() {
                             var data = { selectedIndex: index, 
                                          srcElement: $(target), 
+                                         originalEvent: event,
                                          item: self.dataProvider[index]  };
                             var e = jQuery.Event("change", data);
                             self.$el.trigger( e );


### PR DESCRIPTION
without access to the original event, it's impossible to tell what markup may have been clicked on

this pull request passes the original click event into the `change` handler so you can know which element was clicked inside a `.megalist` 
